### PR TITLE
Fix wrapping for mobile views

### DIFF
--- a/src/components/PortfolioItem.css
+++ b/src/components/PortfolioItem.css
@@ -32,8 +32,14 @@
   margin: 10px 0;
 }
 
+.portfolio-project-tags {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .portfolio-item-tag {
   margin-right: 6px;
+  margin-bottom: 6px;
   padding: 2px 8px;
   border-radius: 2px;
   background-color: #ddd;


### PR DESCRIPTION
* Currently when looking at an item with a bunch of tags
in the mobile view, the tags just overflow off the page
* Now the tags will wrap around